### PR TITLE
chore: minor hardening pass (XSS, concurrency, public-only comment)

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -9,6 +9,13 @@ on:
 permissions:
   contents: write
 
+# Prevent overlapping runs (cron + manual dispatch) from racing on the same
+# data file. Queue subsequent runs rather than cancelling — each tick still
+# carries fresh traffic data worth preserving.
+concurrency:
+  group: collect-traffic
+  cancel-in-progress: false
+
 jobs:
   collect:
     runs-on: ubuntu-latest

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,8 +312,8 @@ async function main() {
 }
 
 main().catch(err => {
-  const main = document.querySelector("main");
-  main.replaceChildren();
+  const mainEl = document.querySelector("main");
+  mainEl.replaceChildren();
   const card = document.createElement("div");
   card.className = "card";
   const h2 = document.createElement("h2");
@@ -321,7 +321,7 @@ main().catch(err => {
   const pre = document.createElement("pre");
   pre.textContent = String(err);
   card.append(h2, pre);
-  main.appendChild(card);
+  mainEl.appendChild(card);
 });
 </script>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -254,12 +254,21 @@ function renderTotals(views, clones) {
   }));
   rows.sort((a, b) => (b.views + b.clones) - (a.views + a.clones));
   const tbody = document.querySelector("#totals-table tbody");
+  const owner = document.getElementById("owner-link").textContent;
   rows.forEach(r => {
     const tr = document.createElement("tr");
-    const owner = document.getElementById("owner-link").textContent;
-    tr.innerHTML = `<td><a href="https://github.com/${owner}/${r.repo}">${r.repo}</a></td>`
-      + `<td class="num">${r.views.toLocaleString()}</td>`
-      + `<td class="num">${r.clones.toLocaleString()}</td>`;
+    const repoCell = document.createElement("td");
+    const link = document.createElement("a");
+    link.href = `https://github.com/${owner}/${r.repo}`;
+    link.textContent = r.repo;
+    repoCell.appendChild(link);
+    const viewsCell = document.createElement("td");
+    viewsCell.className = "num";
+    viewsCell.textContent = r.views.toLocaleString();
+    const clonesCell = document.createElement("td");
+    clonesCell.className = "num";
+    clonesCell.textContent = r.clones.toLocaleString();
+    tr.append(repoCell, viewsCell, clonesCell);
     tbody.appendChild(tr);
   });
 }
@@ -303,8 +312,16 @@ async function main() {
 }
 
 main().catch(err => {
-  document.querySelector("main").innerHTML =
-    `<div class="card"><h2>Error</h2><pre>${err}</pre></div>`;
+  const main = document.querySelector("main");
+  main.replaceChildren();
+  const card = document.createElement("div");
+  card.className = "card";
+  const h2 = document.createElement("h2");
+  h2.textContent = "Error";
+  const pre = document.createElement("pre");
+  pre.textContent = String(err);
+  card.append(h2, pre);
+  main.appendChild(card);
 });
 </script>
 </body>

--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -29,7 +29,12 @@ for old_name in $existing_repos; do
   fi
 done
 
-# List all public repositories
+# List all public repositories.
+# IMPORTANT: `?type=public` is the *only* gate that keeps this tool from
+# touching private repos. The PAT may grant access to all repos (read-only
+# Administration), but we deliberately filter here so traffic data for
+# private repos is never fetched, stored, or published. Do not remove or
+# weaken this filter without auditing the downstream pipeline.
 repos=$(gh api "users/${OWNER}/repos?type=public&per_page=100" --jq '.[].name' | sort)
 
 for repo in $repos; do


### PR DESCRIPTION
## Summary

Three small, independent hardening tweaks bundled into one PR:

- **`scripts/collect.sh`** — Strengthen the comment around the `?type=public` filter. It is the *only* gate that stops this tool from fetching private-repo traffic, even when the PAT happens to grant broader access. Future contributors should know not to weaken it casually.
- **`.github/workflows/collect.yml`** — Add a `collect-traffic` concurrency group. Cron and manual `workflow_dispatch` runs now queue rather than race on `data/traffic.json`. `cancel-in-progress: false` because each tick still carries fresh traffic data worth preserving.
- **`docs/index.html`** — Replace `innerHTML` with DOM APIs in `renderTotals` and the error fallback. The data is owner-controlled (your own repo's `traffic.json`), so the practical risk is tiny, but `textContent` / `createElement` is the right idiom and removes the XSS surface entirely.

## Test plan

- [ ] CI: `Collect Traffic Data` workflow passes on this branch (the workflow change applies on the default branch only, but YAML syntax can be checked here)
- [ ] Local: open `docs/index.html` against a fork URL — totals table still renders, dark/light mode unaffected
- [ ] After merge: trigger `gh workflow run collect.yml` and confirm a second concurrent dispatch queues instead of running in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)