### PR TITLE
ci: pin actions/checkout to commit SHA (v6.0.2)

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -20,7 +20,11 @@ jobs:
   collect:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # Third-party Actions are pinned to a full commit SHA (with the human-
+      # readable version in a trailing comment) per GitHub's supply-chain
+      # hardening guidance. Dependabot keeps the pin current via PRs — do
+      # not "clean up" the SHA back to a tag.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Collect traffic data
         env:


### PR DESCRIPTION
## Summary

Pin `actions/checkout` to the full commit SHA `de0fac2e4500dabe0009e67214ff5f5447ce83dd` (v6.0.2) instead of the moving `@v6` tag, per GitHub's supply-chain hardening guidance. A short comment in the workflow explains the convention so future contributors don't "clean it up" back to a tag.

This pairs with #6 (Enable Dependabot for GitHub Actions) — once Dependabot is on, it will open PRs that bump both the SHA and the trailing version comment in lockstep.

Closes #4.

## Test plan

- [ ] CI: workflow YAML still parses (the GitHub Actions schema accepts SHA refs identically to tag refs)
- [ ] After merge: trigger `gh workflow run collect.yml` and confirm the run still succeeds with the SHA-pinned checkout

## References

- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)