### PR TITLE
ci: enable Dependabot for github-actions (and pin lint.yml checkout)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,9 @@ jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      # SHA-pinned per supply-chain hardening guidance; Dependabot keeps it
+      # current. See .github/workflows/collect.yml for the full rationale.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Run shellcheck
         run: shellcheck scripts/*.sh


### PR DESCRIPTION
## Summary

- Add `.github/dependabot.yml` enabling weekly checks on the `github-actions` ecosystem. Once SHA-pinned Actions exist (#4 / PR #10), Dependabot will open update PRs that bump both the SHA and the trailing version comment when new releases ship.
- Pin `actions/checkout` in `.github/workflows/lint.yml` to the same SHA used in `collect.yml` (`de0fac2e...` # v6.0.2). PR #10 missed this file; Dependabot does **not** migrate `@<tag>` refs to `@<sha>` refs on its own, so leaving `lint.yml` on `@v6` would have left a gap in the supply-chain hardening intent of #4.

Closes #6.

## Test plan

- [ ] CI: `Lint` workflow still runs (`shellcheck scripts/*.sh`) on push/PR touching `scripts/**`
- [ ] After merge: confirm Dependabot picks up the new config (Settings → Security & analysis → Dependabot, or watch the Insights → Dependency graph tab). First Dependabot PRs typically appear within a day.

## References

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)