### PR TITLE
refactor(collect): restrict rename loop to public repos

### DIFF
--- a/scripts/collect.sh
+++ b/scripts/collect.sh
@@ -13,13 +13,33 @@ if [[ ! -f "$DATA_FILE" ]]; then
   echo '{"updated_at":"","views":{},"clones":{}}' > "$DATA_FILE"
 fi
 
+# Compute the public repo list once. This is the single source of truth for
+# "which repos are in scope" and is shared by both the rename reconciliation
+# loop below and the data-collection loop further down.
+#
+# IMPORTANT: `?type=public` is the *only* gate that keeps this tool from
+# touching private repos. The PAT may grant access to all repos (read-only
+# Administration), but we deliberately filter here so traffic data for
+# private repos is never fetched, stored, or published. Do not remove or
+# weaken this filter without auditing the downstream pipeline.
+public_repos=$(gh api "users/${OWNER}/repos?type=public&per_page=100" --jq '.[].name' | sort)
+
 # Reconcile repository renames.
 # GitHub API 301-redirects old names to new ones; the returned .name is the
 # canonical current name. Merge any renamed repo's history into the new key.
+#
+# To preserve the public-only invariant, we (a) skip the probe entirely when
+# old_name is still in the current public list (no rename could have
+# happened), and (b) only honor a detected rename when new_name is also in
+# the public list — so historical data is never reorganized toward a
+# private repo's name even if a private name ever sneaks into traffic.json.
 existing_repos=$(jq -r '[(.views // {} | keys[]), (.clones // {} | keys[])] | unique[]' "$DATA_FILE")
 for old_name in $existing_repos; do
+  echo "$public_repos" | grep -qFx "$old_name" && continue
+
   new_name=$(gh api "repos/${OWNER}/${old_name}" --jq '.name' 2>/dev/null || echo "")
   if [[ -n "$new_name" && "$new_name" != "$old_name" ]]; then
+    echo "$public_repos" | grep -qFx "$new_name" || continue
     echo "Detected rename: ${old_name} -> ${new_name}"
     jq --arg old "$old_name" --arg new "$new_name" '
         .views[$new]  = ((.views[$new]  // {}) * (.views[$old]  // {}))
@@ -29,13 +49,7 @@ for old_name in $existing_repos; do
   fi
 done
 
-# List all public repositories.
-# IMPORTANT: `?type=public` is the *only* gate that keeps this tool from
-# touching private repos. The PAT may grant access to all repos (read-only
-# Administration), but we deliberately filter here so traffic data for
-# private repos is never fetched, stored, or published. Do not remove or
-# weaken this filter without auditing the downstream pipeline.
-repos=$(gh api "users/${OWNER}/repos?type=public&per_page=100" --jq '.[].name' | sort)
+repos="$public_repos"
 
 for repo in $repos; do
   echo "Collecting traffic for ${OWNER}/${repo}..."


### PR DESCRIPTION
## Summary

Tighten `scripts/collect.sh` so the rename reconciliation loop participates in the same public-only invariant the data-collection loop already enforces.

The previous code probed `gh api repos/OWNER/<old_name>` for *every* historical repo name in `traffic.json`, regardless of whether that name was still in the current public list. This meant:

- Redundant API calls for the common steady-state case (most names are still in the public list — no rename to detect).
- A defence-in-depth gap: if a private repo's name ever ended up in `traffic.json` (e.g. via a manual edit), the loop would touch the GitHub API on it, and a renamed-to-private result would migrate historical data toward a name we'd never collect again.

This PR computes the public repo list once at the top of the script, then:

1. **Skip the rename probe** when `old_name` is still in `public_repos` — no rename is possible there. This also eliminates ~N redundant API calls on a normal run.
2. **Only honor a detected rename** when `new_name` is also in `public_repos` — so historical data is never reorganized toward a private destination.
3. **Reuse `public_repos`** in the data-collection loop instead of refetching with a second `gh api users/.../repos?type=public` call.

The probe still runs for names that have left the public list (renamed-away, deleted, or made private). That's inherent to detecting renames — we can't tell those cases apart without asking GitHub. The PAT remains read-only Administration, so this is purely defence-in-depth, not a fix for an active vulnerability — as noted in #9.

Closes #9.

## Test plan

- [x] `bash -n scripts/collect.sh` passes
- [x] `shellcheck scripts/collect.sh` passes
- [x] Manual trace through scenarios (rename, deletion, private-flip, all-steady) — all behave correctly; see commit message
- [ ] After merge: `gh workflow run collect.yml` succeeds and `data/traffic.json` continues to update normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)