### PR TITLE
feat(charts): publish Insights to GitHub Actions step summary

### DIFF
--- a/scripts/generate-charts.sh
+++ b/scripts/generate-charts.sh
@@ -137,5 +137,12 @@ else
   fi
 fi
 
+# When running under GitHub Actions, also publish the same Insights block
+# to the run's step summary so each cron tick is glanceable from the
+# Actions tab without opening README or the dashboard.
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  cat charts.md >> "$GITHUB_STEP_SUMMARY"
+fi
+
 rm -f charts.md
 echo "Charts updated in ${README}"


### PR DESCRIPTION
## Summary

Append the same `charts.md` content that's already being inserted into `README.md` to `$GITHUB_STEP_SUMMARY` when running under GitHub Actions. The Mermaid charts then render directly on each cron run's Actions page — opening README or the live dashboard becomes optional for a quick glance.

- **No data duplication**: reuses the existing `charts.md` artifact in `generate-charts.sh` before it's `rm -f`'d
- **No workflow YAML change**: the script discovers it's in Actions via `$GITHUB_STEP_SUMMARY`; local invocations are unaffected
- **No new dependencies**: GitHub renders Mermaid in step summaries the same way it does in issues/READMEs

Closes #5.

## Test plan

- [x] `bash -n scripts/generate-charts.sh` passes
- [x] `shellcheck scripts/generate-charts.sh` passes
- [x] Local run (no `$GITHUB_STEP_SUMMARY` set) behaves identically — the new `if` block is a no-op
- [ ] After merge: trigger `gh workflow run collect.yml` and confirm the Insights block (Mermaid charts + repository table) renders on the run's summary page

## References

- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary
- https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/

🤖 Generated with [Claude Code](https://claude.com/claude-code)