### PR TITLE
feat(actions): auto-refresh README screenshot via Playwright

### DIFF
--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -36,10 +36,19 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_INSIGHTS_PAT }}
         run: bash scripts/generate-charts.sh
 
+      # Refresh README screenshot from the live dashboard. Soft-failure on
+      # purpose — a hiccup here must not block the daily traffic collection.
+      - name: Update screenshot
+        continue-on-error: true
+        run: |
+          npm install --no-save playwright@1.59.1
+          npx playwright install --with-deps chromium
+          node scripts/screenshot.js
+
       - name: Commit and push
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add data/traffic.json README.md
+          git add data/traffic.json README.md docs/screenshot.png
           git diff --cached --quiet || git commit -m "chore: update traffic data $(date -u +%Y-%m-%d)"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Capture a fresh dashboard screenshot to docs/screenshot.png.
+//
+// Runs in the daily Actions cron after data is collected. Note the inherent
+// 1-tick lag: GitHub Pages redeploys asynchronously after the data push, so
+// the screenshot captures the *previous* run's data. Acceptable for what is
+// effectively marketing imagery in README — the live link sits right above
+// it for current data.
+
+const { chromium } = require('playwright');
+
+const owner = process.env.GITHUB_REPOSITORY_OWNER || 'shigechika';
+const repo = (process.env.GITHUB_REPOSITORY || 'shigechika/github-insights').split('/')[1];
+const url = `https://${owner}.github.io/${repo}/`;
+const out = 'docs/screenshot.png';
+
+(async () => {
+  console.log(`Capturing ${url} -> ${out}`);
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({
+      viewport: { width: 1280, height: 800 },
+      deviceScaleFactor: 2,
+      colorScheme: 'light',
+    });
+    const page = await context.newPage();
+    await page.goto(url, { waitUntil: 'networkidle', timeout: 60000 });
+    // Chart.js draws to <canvas> after fetching data. Wait for the canvases
+    // to exist, then a short settle for animations.
+    await page.waitForSelector('canvas');
+    await page.waitForTimeout(2000);
+    await page.screenshot({ path: out, fullPage: true });
+    console.log(`Saved ${out}`);
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## Summary

Wire the daily Actions cron to refresh `docs/screenshot.png` from the live dashboard, so the README image stays current instead of being frozen at whatever was committed manually months ago.

- **`scripts/screenshot.js`** — Small Playwright/Chromium script. Opens `https://<owner>.github.io/<repo>/`, waits for Chart.js canvases to render, then writes `docs/screenshot.png` at 1280×800 @ 2× DPI, full page. Owner/repo derived from the standard Actions env vars so any fork works without code changes.
- **`.github/workflows/collect.yml`** — Adds a `Update screenshot` step between chart generation and the git push. `continue-on-error: true` so a flaky CDN/Pages hiccup never blocks the daily traffic collection (the workflow's primary goal). `docs/screenshot.png` joins `data/traffic.json` and `README.md` in the same daily commit.
- **`.gitignore`** — New file. Keeps `node_modules/` and `package-lock.json` out of the repo if anyone runs the script locally; the workflow uses `npm install --no-save` so CI doesn't write them either.

### Inherent 1-tick lag

GitHub Pages redeploys asynchronously after each push, so the screenshot captures the *previous* run's data, not today's. Fine for what is essentially marketing imagery — the live dashboard link sits right above the image in README for current data.

### Pinning notes

- `playwright@1.59.1` is hardcoded in the workflow YAML. Dependabot for github-actions doesn't track npm; this would need manual bumps (or a follow-up to add a tiny `package.json` for npm Dependabot).
- `actions/checkout` is already SHA-pinned via #11.
- `chromium` is downloaded fresh per run (~30 sec). Caching via `actions/cache` is a possible follow-up if cold-install time ever becomes annoying.

## Test plan

- [x] Local: `node --check scripts/screenshot.js` — passes (machine has a broken local node lib but `--check` returns OK; the script is plain CommonJS + a few playwright API calls)
- [ ] After merge: trigger `gh workflow run collect.yml` and confirm
  - the `Update screenshot` step succeeds
  - `docs/screenshot.png` shows the dashboard with the *previous* run's data
  - the README screenshot link still renders
- [ ] After 2nd run: confirm the screenshot keeps updating each tick

## References

- https://playwright.dev/docs/api/class-page#page-screenshot
- https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-using-continue-on-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)