### PR TITLE
fix(screenshot): crop to charts only (drop the long table tail)

### DIFF
--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -18,8 +18,13 @@ const out = 'docs/screenshot.png';
   console.log(`Capturing ${url} -> ${out}`);
   const browser = await chromium.launch();
   try {
+    // Crop to the two chart cards (Daily Views + Daily Clones). Below them
+    // sits a 50+ row Repository totals table which makes a fullPage capture
+    // dominated by a long tail. Viewport height 1125 (CSS px) lands just at
+    // the bottom of the second card; with deviceScaleFactor 2 the resulting
+    // PNG is 2560×2250.
     const context = await browser.newContext({
-      viewport: { width: 1280, height: 800 },
+      viewport: { width: 1280, height: 1125 },
       deviceScaleFactor: 2,
       colorScheme: 'light',
     });
@@ -29,7 +34,7 @@ const out = 'docs/screenshot.png';
     // to exist, then a short settle for animations.
     await page.waitForSelector('canvas');
     await page.waitForTimeout(2000);
-    await page.screenshot({ path: out, fullPage: true });
+    await page.screenshot({ path: out, fullPage: false });
     console.log(`Saved ${out}`);
   } finally {
     await browser.close();


### PR DESCRIPTION
## Summary

Follow-up to #15. The first auto-screenshot ran and produced a 2560×6040 image because `fullPage: true` captured the entire dashboard — including the Repository totals table with 50+ rows. The result was a marketing image that is roughly two charts at the top followed by a very long tail.

This PR switches to a viewport-only capture sized so it lands at the bottom of the Daily Clones card:

- `viewport: { width: 1280, height: 1125 }` (CSS px) — measured against the prior fullPage capture in macOS Preview at 2250 px = 1125 / DPR-2
- `fullPage: false` — explicit, even though it's the default

Resulting PNG: **2560×2250**, containing the header + Daily Views + Daily Clones cards. Repository totals card is dropped from the marketing image (the live dashboard still has it; the README still links there).

## Test plan

- [ ] After merge: trigger `gh workflow run collect.yml` and confirm:
  - the new `docs/screenshot.png` is 2560×2250
  - the image shows both stacked area charts and stops at the bottom of the second card
  - the README image link renders without the long-tail look

## Notes

- If a future cron run shows the table partially visible at the bottom, the cards' header/legend layout has changed — bump the height a small amount and re-measure
- This is purely a cosmetic tweak to the auto-screenshot from #15; no other behaviour changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)