### PR TITLE
feat: sort Repositories table by combined traffic

### DIFF
--- a/scripts/generate-charts.sh
+++ b/scripts/generate-charts.sh
@@ -95,13 +95,20 @@ clones_bar=$(jq -r --arg days "${views_days} days" '
   echo ""
   echo "### Repositories"
   echo ""
-  # Collect all repos that appear in views or clones charts (top 8 each), deduplicate
+  # Collect repos from views/clones top 8 each, deduplicate, sort by combined traffic desc
   jq -r '
-    ([.views | to_entries[] | {repo: .key, total: ([.value | to_entries[].value.count] | add)}]
-      | sort_by(-.total) | [.[] | select(.total > 0)] | .[0:8] | .[].repo),
-    ([.clones | to_entries[] | {repo: .key, total: ([.value | to_entries[].value.count] | add)}]
-      | sort_by(-.total) | [.[] | select(.total > 0)] | .[0:8] | .[].repo)
-  ' "$DATA_FILE" | sort -u | {
+    ([.views | to_entries[] | {key: .key, value: ([.value | to_entries[].value.count] | add // 0)}] | from_entries) as $vt |
+    ([.clones | to_entries[] | {key: .key, value: ([.value | to_entries[].value.count] | add // 0)}] | from_entries) as $ct |
+    [
+      ([.views | to_entries[] | {repo: .key, total: ([.value | to_entries[].value.count] | add)}]
+        | sort_by(-.total) | [.[] | select(.total > 0)] | .[0:8][].repo),
+      ([.clones | to_entries[] | {repo: .key, total: ([.value | to_entries[].value.count] | add)}]
+        | sort_by(-.total) | [.[] | select(.total > 0)] | .[0:8][].repo)
+    ] | unique
+    | map({repo: ., total: (($vt[.] // 0) + ($ct[.] // 0))})
+    | sort_by(-.total)
+    | .[].repo
+  ' "$DATA_FILE" | {
     echo "| Repository | Description |"
     echo "| --- | --- |"
     while read -r repo; do


### PR DESCRIPTION
## Summary

- Repositories table in README was alphabetically sorted via `sort -u`
- Now sorted by combined views + clones total (descending), so the most-visited repos appear first

## How it works

jq computes `$vt` (views totals per repo) and `$ct` (clones totals per repo) as lookup maps, then for the union of top-8 view repos and top-8 clone repos, sorts by `$vt[repo] + $ct[repo]` descending.

## Test plan

- [ ] Verify output order with current data: `mcp-stdio (2990) → jquants-mcp (2313) → github-insights (1992) → ...`
- [ ] Confirm next cron run updates the table correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)