### PR TITLE
docs: polish language switcher and Japanese subtitle

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,8 +1,8 @@
 # github-insights
 
-[shigechika](https://github.com/shigechika) リポジトリの GitHub トラフィックインサイト
+[shigechika](https://github.com/shigechika) リポジトリの GitHub トラフィックインサイトダッシュボード
 
-[English](README.md)
+[English](README.md) | 日本語
 
 **ライブダッシュボード**: https://shigechika.github.io/github-insights/
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 GitHub Traffic insights dashboard for [shigechika](https://github.com/shigechika) repositories.
 
-[日本語](README.ja.md)
+English | [日本語](README.ja.md)
 
 **Live dashboard**: https://shigechika.github.io/github-insights/
 


### PR DESCRIPTION
## Summary

- Language switcher: current language shown as plain text, other as link
  - `README.md`: `English | [日本語](README.ja.md)`
  - `README.ja.md`: `[English](README.md) | 日本語`
- Japanese subtitle: `トラフィックインサイト` → `トラフィックインサイトダッシュボード` (matches English heading)

🤖 Generated with [Claude Code](https://claude.com/claude-code)