### PR TITLE
chore: ignore local .claude/ settings directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules/
 package-lock.json
+
+# Local Claude Code settings (per-developer, not shared)
+.claude/


### PR DESCRIPTION
## What

Add `.claude/` to `.gitignore`.

## Why

Claude Code writes per-developer settings into `.claude/` (e.g. `settings.local.json`, `scheduled_tasks.lock`). These are local-only and were showing up as untracked in `git status`. Ignoring the directory keeps the working tree clean and prevents accidental commits of local config.

No runtime or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)